### PR TITLE
docs: IntExt.format に doc コメントを追加

### DIFF
--- a/lib/util/int_ext.dart
+++ b/lib/util/int_ext.dart
@@ -3,5 +3,6 @@ import 'package:intl/intl.dart';
 final _thousandsSeparatedFormat = NumberFormat('#,###');
 
 extension IntExt on int {
+  /// 数字を千単位でカンマ区切りにする
   String get format => _thousandsSeparatedFormat.format(this);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_github_client
 description: "A new Flutter project."
 publish_to: 'none'
 
-version: 1.0.0+2
+version: 1.0.0+3
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
## 変更内容

`lib/util/int_ext.dart` の `format` getter に doc コメントを追加しました。

- 数字を千単位でカンマ区切りにする機能であることを明記

Made with [Cursor](https://cursor.com)